### PR TITLE
Prepare 1.0.1

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tinydir_vendor</name>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <description>CMake shim over tinydir: https://github.com/cxong/tinydir/</description>
   <maintainer email="ros-contributions@amazon.com">AWS RoboMaker</maintainer>
   <maintainer email="steven@openrobotics.org">Steven! Ragnarök</maintainer>


### PR DESCRIPTION
I'd like to cut a new release including #3 so we can get the buildfarm binary building. If this PR is approved I'll fast-forward this commit onto master and tag it as 1.0.1 then release it with bloom.