### PR TITLE
Enable linter tests on tinydir_vendor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if(DEFINED CMAKE_TOOLCHAIN_FILE)
 endif()
 
 include(ExternalProject)
-ExternalProject_Add(tinydir-1.2.4
+externalproject_add(tinydir-1.2.4
   PREFIX tinydir-1.2.4
   URL https://github.com/cxong/tinydir/archive/1.2.4.tar.gz
   URL_MD5 15978c5f498e2ff3d26a9975c734cda0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,22 @@ install(
 configure_file(tinydir_vendorConfig.cmake.in "${PROJECT_BINARY_DIR}/tinydir_vendorConfig.cmake" @ONLY)
 configure_file(tinydir_vendorConfig-version.cmake.in "${PROJECT_BINARY_DIR}/tinydir_vendorConfig-version.cmake" @ONLY)
 
+find_package(ament_cmake_test QUIET)
+if(BUILD_TESTING)
+  find_package(ament_cmake_copyright QUIET)
+  find_package(ament_cmake_lint_cmake QUIET)
+  find_package(ament_cmake_xmllint QUIET)
+  if(ament_cmake_copyright_FOUND)
+    ament_copyright()
+  endif()
+  if(ament_cmake_lint_cmake_FOUND)
+    ament_lint_cmake()
+  endif()
+  if(ament_cmake_xmllint_FOUND)
+    ament_xmllint()
+  endif()
+endif()
+
 install(FILES
   package.xml
   DESTINATION share/${PROJECT_NAME})

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,3 +59,18 @@ If you discover a potential security issue in this project we ask that you notif
 See the [LICENSE](https://github.com/aws-robotics/vendored-tinydir/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
 
 We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.
+
+
+Any contribution that you make to this repository will
+be under the Apache 2 License, as dictated by that
+[license](http://www.apache.org/licenses/LICENSE-2.0.html):
+
+~~~
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+~~~

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,6 @@
   
   <buildtool_depend>cmake</buildtool_depend>
 
-  <test_depend>ament_package</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_test</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,12 @@
   
   <buildtool_depend>cmake</buildtool_depend>
 
+  <test_depend>ament_package</test_depend>
+  <test_depend>ament_cmake_copyright</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_test</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+
   <export>
     <build_type>cmake</build_type>
   </export>


### PR DESCRIPTION
Added linters on the package aiming to increase package quality level to 1.
Fixed issues caused cmake_lint and copyright tests to fail

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.